### PR TITLE
feat(accordion): add accordion component main behaviors

### DIFF
--- a/packages/components/accordion/README.md
+++ b/packages/components/accordion/README.md
@@ -9,3 +9,119 @@ const accordion = require('accordion');
 
 // TODO: DEMONSTRATE API
 ```
+
+## HTML before without name attr
+
+```html
+<section is="wcag-accordion">
+  <details>
+    <summary>
+      {{title}}
+    </summary>
+    {{content}}
+  </details>
+  <details>
+    <summary>
+      {{title}}
+    </summary>
+    {{content}}
+  </details>
+</section>
+```
+
+## HTML after without name attr
+
+```html
+<section is="wcag-accordion">
+  <details name="{{uuid}}-accordion">
+    <summary>
+      {{title}}
+    </summary>
+    {{content}}
+  </details>
+  <details name="{{uuid}}-accordion">
+    <summary>
+      {{title}}
+    </summary>
+    {{content}}
+  </details>
+</section>
+```
+
+## HTML before without name attr
+
+```html
+<section is="wcag-accordion">
+  <details>
+    <summary>
+      {{title}}
+    </summary>
+    {{content}}
+  </details>
+  <details>
+    <summary>
+      {{title}}
+    </summary>
+    {{content}}
+  </details>
+</section>
+```
+
+## HTML after without name attr
+
+```html
+<section is="wcag-accordion">
+  <details name="{{uuid}}-accordion">
+    <summary>
+      {{title}}
+    </summary>
+    {{content}}
+  </details>
+  <details name="{{uuid}}-accordion">
+    <summary>
+      {{title}}
+    </summary>
+    {{content}}
+  </details>
+</section>
+```
+
+----
+
+## HTML before with name attr
+
+```html
+<section is="wcag-accordion" name="{{NAME}}">
+  <details>
+    <summary>
+      {{title}}
+    </summary>
+    {{content}}
+  </details>
+  <details>
+    <summary>
+      {{title}}
+    </summary>
+    {{content}}
+  </details>
+</section>
+```
+
+## HTML after with name attr
+
+```html
+<section is="wcag-accordion" name="{{NAME}}">
+  <details name="{{NAME}}">
+    <summary>
+      {{title}}
+    </summary>
+    {{content}}
+  </details>
+  <details name="{{NAME}}">
+    <summary>
+      {{title}}
+    </summary>
+    {{content}}
+  </details>
+</section>
+```

--- a/packages/components/accordion/lib/accordion.attributes.js
+++ b/packages/components/accordion/lib/accordion.attributes.js
@@ -1,10 +1,7 @@
-import { events } from "@wcag-ui/core";
+import { events } from '@wcag-ui/core';
 
 export default {
-  // open: function (oldValue, newValue) {
-  //   const state = newValue === null ? "close" : "open";
-  //   this.setAttribute("aria-expanded", (state === "open").toString());
-
-  //   events.dispatchComponentEvent.call(this, "toggle", { state });
-  // },
+  name: function () {
+    this.update();
+  },
 };

--- a/packages/components/accordion/lib/accordion.events.js
+++ b/packages/components/accordion/lib/accordion.events.js
@@ -1,8 +1,10 @@
+import { events } from '@wcag-ui/core';
+
 export default {
-  // click: function (e) {
-  //   console.log("button clicked", this.textContent);
-  // },
-  // focus: function (e) {
-  //   console.log("button focused", this.textContent);
-  // },
+  'wcag-details.toggle': function (e) {
+    // NOTE: this works only with <details is="wcag-details">
+    // because native element doesn't bubble the `toggle` event
+
+    events.dispatchComponentEvent.call(this, 'toggle', {});
+  },
 };

--- a/packages/components/accordion/lib/accordion.js
+++ b/packages/components/accordion/lib/accordion.js
@@ -1,10 +1,10 @@
 import { componentDecorator, helpers } from "@wcag-ui/core";
 import { DOM } from "@wcag-ui/dom";
 
-import "./styles/accordion.css";
+import './styles/accordion.css';
 
-import attributes from "./accordion.attributes";
-import events from "./accordion.events";
+import attributes from './accordion.attributes';
+import events from './accordion.events';
 
 /**
  * wcagUI Accordion class
@@ -14,8 +14,8 @@ import events from "./accordion.events";
  * @extends {HTMLElement}
  */
 export class Accordion extends HTMLElement {
-  static name = "wcag-accordion";
-  static extends = "section";
+  static name = 'wcag-accordion';
+  static extends = 'section';
   static attributes = attributes;
   static events = events;
 
@@ -26,11 +26,35 @@ export class Accordion extends HTMLElement {
    * @memberof Accordion
    */
   static {
-    componentDecorator("Accordion", Accordion);
+    componentDecorator('Accordion', Accordion);
   }
 
   #guid = helpers.strings.guid();
-  #items;
+
+  get name() {
+    return this.getAttribute('name') ?? `${this.#guid}-accordion`;
+  }
+
+  set name(name) {
+    this.setAttribute('name', name ?? `${this.#guid}-accordion`);
+    this.update();
+  }
+
+  #mutationObserver;
+
+  #mutationHandler(mutations) {
+    for (const mutation of mutations) {
+      (mutation.type === 'childList' || mutation.type === 'attribute') && this.update();
+    }
+  }
+
+  update() {
+    const name = this.name;
+
+    for (const item of this.querySelectorAll(':scope > details')) {
+      item.setAttribute('name', name);
+    }
+  }
 
   constructor() {
     super();
@@ -39,10 +63,15 @@ export class Accordion extends HTMLElement {
   }
 
   #initialize() {
-    this.#items = this.querySelectorAll(":scope > details");
+    this.#mutationObserver = new MutationObserver(this.#mutationHandler.bind(this));
 
-    for (const item of this.#items) {
-      item.setAttribute("name", `${this.#guid}-accordion`);
-    }
+    this.#mutationObserver.observe(this, {
+      attributes: true,
+      attributeFilter: ['name'],
+      childList: true,
+      subtree: false,
+    });
+
+    this.update();
   }
 }

--- a/packages/components/details/lib/details.events.js
+++ b/packages/components/details/lib/details.events.js
@@ -1,8 +1,1 @@
-export default {
-  // click: function (e) {
-  //   console.log("button clicked", this.textContent);
-  // },
-  // focus: function (e) {
-  //   console.log("button focused", this.textContent);
-  // },
-};
+export default {};

--- a/src/components-accordion.html
+++ b/src/components-accordion.html
@@ -4,5 +4,15 @@
   </block>
   <block name="main">
     <h1>Accordion Docs Example</h1>
+    <section is="wcag-accordion" name="accordion-test">
+      <details is="wcag-details">
+        <summary>Details group 1</summary>
+        Details content 1
+      </details>
+      <details>
+        <summary>Details group 2</summary>
+        Details content 2
+      </details>
+    </section>
   </block>
 </extends>


### PR DESCRIPTION
- handles only `<details>` element children
- if `<details>` child is a "wcag-details" the "wcag-details.toggle" event is handled and a "wcag-accordion.toggle" is emitted
- name attribute is watched and updates all the name attributes of `<details>` children
- name can be updated/read with public setter/getter
- a mutation observer watches for attribute changes and for childList changes, updating every `<details>` child with the proper name attribute
- if the name attribute is not present, there's a `{{UUID}}-accordion` fallback